### PR TITLE
Add ability to run code as generator aka sleep() support

### DIFF
--- a/chrome/button.js
+++ b/chrome/button.js
@@ -1,1 +1,2 @@
-(new Function (argNames, code)). apply (oButton, args);
+argNames += ",fn"; var fn = new Function (argNames, code); args. push (fn); var gen = fn. apply (oButton, args); if (fn. isGenerator && fn. isGenerator ()) { fn. __generator = gen; gen. next (); }
+// Above code should be in one line for correct error line numbers

--- a/chrome/button.js
+++ b/chrome/button.js
@@ -1,2 +1,2 @@
-argNames += ",fn"; var fn = new Function (argNames, code); args. push (fn); var gen = fn. apply (oButton, args); if (fn. isGenerator && fn. isGenerator ()) { fn. __generator = gen; gen. next (); }
+argNames += ",fn"; var fn = new Function (argNames, code); args. push (fn); var gen = fn. apply (oButton, args); if ("isGenerator" in fn ? fn. isGenerator () : gen && typeof gen.next == "function") { fn. __generator = gen; gen. next (); }
 // Above code should be in one line for correct error line numbers

--- a/chrome/custombuttons/content/custombuttons/cbbutton.js
+++ b/chrome/custombuttons/content/custombuttons/cbbutton.js
@@ -229,6 +229,7 @@ var custombutton = {
 	var utils = {};
 	utils ["oButton"] = oButton;
 	utils ["buttonURI"] = uri;
+	utils ["executionContext"] = executionContext;
 	Components. classes ["@mozilla.org/moz/jssubscript-loader;1"].
 		getService (Components. interfaces. mozIJSSubScriptLoader).
 		loadSubScript ("chrome://custombuttons/content/contextBuilder.js", utils);

--- a/chrome/custombuttons/content/custombuttons/contextBuilder.js
+++ b/chrome/custombuttons/content/custombuttons/contextBuilder.js
@@ -183,3 +183,17 @@ function sleep (ms)
 		fn. __generator. next ();
 	}, ms);
 }
+
+/**
+ * Continue code execution, shortcut for fn. __generator. next ()
+ * @since version 0.0.5.9
+ * @param {number} ms
+ * @throws {TypeError} If used without "yield"
+ */
+function next ()
+{
+	var fn = executionContext. fn;
+	if (!("__generator" in fn))
+		throw new TypeError ("Custom Buttons: next: execution should be paused using \"yield\" keyword", _uri, Components. stack. caller. lineNumber);
+	fn. __generator. next ();
+}

--- a/chrome/custombuttons/content/custombuttons/contextBuilder.js
+++ b/chrome/custombuttons/content/custombuttons/contextBuilder.js
@@ -166,3 +166,20 @@ function addDestructor (func, context)
 	destructor ["context"] = context;
 	oButton. _destructors. push (destructor);
 }
+
+/**
+ * Pause code execution
+ * Usage: ... yield sleep (1000); ... yield 0;
+ * @since version 0.0.5.9
+ * @param {number} ms
+ * @throws {TypeError} If used without "yield"
+ */
+function sleep (ms)
+{
+	var fn = executionContext. fn;
+	if (!("__generator" in fn))
+		throw new TypeError ("Custom Buttons: sleep: use \"yield sleep (ms);\"", _uri, Components. stack. caller. lineNumber);
+	setTimeout (function () {
+		fn. __generator. next ();
+	}, ms);
+}


### PR DESCRIPTION
Added functions: sleep(), next().
Added "fn" argument (link to function itself) + fn.__generator (if available).

Usage examples:

``` js
// Some code
yield sleep(2000); // Pause
alert("Done");
yield 0; // Prevent StopIteration exception
```

``` js
yield setTimeout(function() { // Anything async
    fn.__generator.next(); // Continue execution
}, 1000);
alert("Done");
yield 0; // Prevent StopIteration exception
```

``` js
yield setTimeout(function() { // Anything async
    next(); // Continue execution
}, 1000);
alert("Done");
yield 0; // Prevent StopIteration exception
```
